### PR TITLE
test: ignore version/timestamp fields in expected output comparison

### DIFF
--- a/tests/c2p/framework/test_c2p.py
+++ b/tests/c2p/framework/test_c2p.py
@@ -67,7 +67,9 @@ def test_result_to_oscal():
     assessment_results = c2p.result_to_oscal()
     expect = AssessmentResults.parse_file(EXPECTED_ASSESSMENT_RESULTS_DATA)
 
-    assert_pydantic_object(assessment_results.metadata, expect.metadata, exludes=['last_modified'])
+    assert_pydantic_object(
+        assessment_results.metadata, expect.metadata, exludes=['last_modified', 'version', 'oscal_version']
+    )
     assert_pydantic_object(assessment_results.import_ap, expect.import_ap)
     actual_result = assessment_results.results[0]
     expect_result = expect.results[0]


### PR DESCRIPTION
Signed-off-by: Takumi Yanagawa <yana@jp.ibm.com>

#### What's changes:

- Ignore version fields in unit test validation to prevent failures from library-induced changes.

The `treslte` library update changed the generated `oscal` version field.  
This field is not relevant to our unit test assertions, so we now exclude it from the comparison logic to ensure future updates won't cause test instability.

#### Verification
```
$ make test

plugins_public/tests/plugins/test_auditree.py::test_auditree_pvp_result_to_compliance PASSED                                                                                               [ 16%]
plugins_public/tests/plugins/test_auditree.py::test_auditree_compliance_to_policy PASSED                                                                                                   [ 33%]
plugins_public/tests/plugins/test_kyverno.py::test_kyverno_pvp_result_to_compliance PASSED                                                                                                 [ 50%]
plugins_public/tests/plugins/test_kyverno.py::test_kyverno_compliance_to_policy PASSED                                                                                                     [ 66%]
plugins_public/tests/plugins/test_ocm.py::test_ocm_pvp_result_to_compliance PASSED                                                                                                         [ 83%]
plugins_public/tests/plugins/test_ocm.py::test_ocm_compliance_to_policy 
----------------------------------------------------------------------------------------- live log call ------------------------------------------------------------------------------------------
2025-04-03 08:35:17 [    INFO] The deliverable policy directory '/var/folders/yx/1mv5rdh53xd93bphsc459ht00000gn/T/tmp5o6218pq/deliverable-policy' is not found. Creating... (ocm.py:191)
PASSED                                                                                                                                                                                     [100%]

======================================================================================= 6 passed in 0.35s ========================================================================================

tests/c2p/framework/test_c2p.py::test_result_to_oscal PASSED                                                                                                                               [ 33%]
tests/c2p/test_cli.py::test_run PASSED                                                                                                                                                     [ 66%]
tests/c2p/test_cli.py::test_version PASSED                                                                                                                                                 [100%]

======================================================================================= 3 passed in 0.31s =======================================================================================
```